### PR TITLE
JOSS review revisions: optional TensorFlow, type hints, pipeline docs

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -48,3 +48,35 @@ jobs:
         with:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # TensorFlow is an optional extra. This job installs the base package only and
+  # checks that everything except the CNN detector still works, so the slim
+  # install path cannot silently rot.
+  slim-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🛎️ Checkout code
+        uses: actions/checkout@v6
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: 📥 Install without the cnn extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: 🚫 Assert TensorFlow is absent
+        run: |
+          if pip show tensorflow > /dev/null 2>&1; then
+            echo "TensorFlow was installed by the base package; it must be an extra."
+            exit 1
+          fi
+
+      - name: 🧪 Run the tests that do not need TensorFlow
+        run: |
+          pytest -m "not slow" -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ and to [#72](https://github.com/SerpRateAI/merrypopins/issues/72).
   the edge and post-maximum-load masks they all applied separately. No change in
   behaviour or public API.
 
+### Fixed
+- `detect_popins_savgol` and `detect_popins_fd_fourier` no longer flag arbitrary
+  points on a perfectly smooth curve. Both score candidates as a departure from the
+  mean in units of the derivative's standard deviation. When the curve is smooth the
+  derivative is constant, that standard deviation is floating-point noise around zero
+  rather than a real scale, and the comparison flagged points essentially at random.
+  The shared `_flag_outliers` helper now flags nothing when the spread is negligible
+  relative to the signal, which is correct: a perfectly smooth curve has no pop-ins.
+  This surfaced as a test failure under newer SciPy and NumPy releases.
+
 ### Added
 - A pipeline diagram and a detection-method comparison table in the README and docs,
   plus guidance on `popin`, `popin_score` and `popin_confident`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,3 +49,36 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) 
 ### Changed
 - **Python Compatibility**:
     - As the latest TensorFlow is now compatible with Python 3.13, updated Python compatibility in `pyproject.toml` and classifiers to include Python 3.13.
+## [1.1.0] - 2026-08-07 &nbsp;:package: **"Optional TensorFlow"**
+
+Revisions made in response to the JOSS peer review
+([openjournals/joss-reviews#9933](https://github.com/openjournals/joss-reviews/issues/9933))
+and to [#72](https://github.com/SerpRateAI/merrypopins/issues/72).
+
+### Changed
+- **TensorFlow is now an optional dependency.** It is only needed by the CNN
+  autoencoder detector, one of four methods in `locate`, and it is a
+  several-hundred-megabyte install. Install it with `pip install 'merrypopins[cnn]'`.
+  The base install is now considerably smaller, and `merrypopins` imports and runs
+  without it.
+  - `locate.py` imports Keras lazily inside `build_cnn_autoencoder` and
+    `detect_popins_cnn`, and raises an `ImportError` naming the install command
+    rather than a bare `ModuleNotFoundError`.
+  - `default_locate` still enables the CNN by default (`use_cnn=True`), so on a slim
+    install it raises rather than quietly returning results from three methods when
+    four were requested. Pass `use_cnn=False` for the three-method pipeline.
+  - Conda, Docker, dev and Streamlit environments continue to install TensorFlow, so
+    the tutorials and the hosted app are unaffected.
+- **Type hints** added to the public API of all five modules.
+- The four `detect_popins_*` functions now share a single `_apply_trims` helper for
+  the edge and post-maximum-load masks they all applied separately. No change in
+  behaviour or public API.
+
+### Added
+- A pipeline diagram and a detection-method comparison table in the README and docs,
+  plus guidance on `popin`, `popin_score` and `popin_confident`.
+- Documentation of the optional-extra install path in the README and installation guide.
+- A `slim-install` CI job that installs the base package, asserts TensorFlow is absent,
+  and runs the tests that do not need it.
+- Tests covering the missing-TensorFlow path for `_import_keras`,
+  `build_cnn_autoencoder`, `detect_popins_cnn` and `default_locate`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y \
 
 # Install Python dependencies
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir -e . \
+    && pip install --no-cache-dir -e '.[cnn]' \
     && pip install --no-cache-dir streamlit "plotly<6.0.0" matplotlib "kaleido<1.0.0"
 
 # Set the Streamlit port

--- a/README.md
+++ b/README.md
@@ -43,6 +43,62 @@ Merrypopins is developed by [Cahit Acar](mailto:c.acar.business@gmail.com), [Ann
 
 ---
 
+## 🔄 Workflow
+
+The five modules form a pipeline. Each stage takes the DataFrame the previous stage
+produced, so you can stop anywhere, inspect the result, or swap in your own step.
+
+```mermaid
+flowchart LR
+    RAW[".txt curve<br/>.tdm/.tdx metadata"] --> LOAD["<b>load_datasets</b><br/>parse to DataFrame"]
+    LOAD --> PRE["<b>preprocess</b><br/>trim, find contact,<br/>zero the depth axis"]
+    PRE --> LOC["<b>locate</b><br/>four detectors +<br/>agreement score"]
+    LOC --> STAT["<b>statistics</b><br/>stress-strain, yield point,<br/>precursor & temporal stats"]
+    STAT --> OUT["annotated tables,<br/>summary stats, plots"]
+
+    subgraph WRAP["make_dataset.merrypopins_pipeline (convenience wrapper)"]
+        LOAD
+        PRE
+        LOC
+    end
+```
+
+`make_dataset.merrypopins_pipeline` runs the first three stages end to end on a single
+file and writes an overlay plot, which is the quickest way to check a curve.
+
+---
+
+## 🔎 Choosing a detection method
+
+`locate` offers four detectors. They are complementary rather than interchangeable:
+the two derivative methods are cheap and predictable, and the two unsupervised
+learning methods adapt to data whose pop-in sizes you do not know in advance.
+
+| Method | Function | How it flags a pop-in | Main parameters | TensorFlow | Cost | Suits |
+|---|---|---|---|---|---|---|
+| Savitzky-Golay | `detect_popins_savgol` | Polynomial-smoothed derivative of load, thresholded in standard deviations | `window_length`, `polyorder`, `threshold` | no | very low | A first pass over a large batch; smooth, low-noise curves |
+| Fourier derivative | `detect_popins_fd_fourier` | Derivative taken in the frequency domain, thresholded in standard deviations | `threshold`, `spacing` | no | very low | Sharp discontinuities, with almost nothing to tune |
+| Isolation Forest | `detect_popins_iforest` | Unsupervised outlier detection over (stiffness difference, curvature) | `contamination`, `window` | no | low | Curves where pop-in size and frequency are not known beforehand |
+| CNN autoencoder | `detect_popins_cnn` | Reconstruction error over sliding windows of the same two features | `window_size`, `epochs`, `threshold_multiplier` | **yes** | high | Noisy curves and subtle nonlinear signatures a fixed threshold misses |
+
+Neither learning method uses pre-trained weights. Both are fitted, unsupervised, on the
+curve you pass in, so no labelled training data is needed and results depend only on
+that curve and your parameters.
+
+`default_locate` runs the enabled methods and combines them into three columns:
+
+| Column | Meaning |
+|---|---|
+| `popin` | Any enabled method fired here (the inclusive union). Highest recall. |
+| `popin_score` | How many methods fired here, i.e. how strongly they agree. |
+| `popin_confident` | At least two methods agree. Use this when a false positive costs more than a missed event. |
+
+Comparing `popin_score` across methods is also a cheap self-consistency check: events
+that only one detector sees are worth inspecting on the overlay plot before you trust them.
+
+
+---
+
 ## 🌐 Try Merrypopins Library Online
 
 🚀 **Live demo**: explore Merrypopins in your browser! [![Open in Streamlit](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://merrypopins.streamlit.app)
@@ -89,13 +145,16 @@ These images highlight the complex deformation behavior analyzed by the `merrypo
 ## Installation
 
 ```bash
-# From PyPI
+# Full install, including the CNN pop-in detector (recommended)
+pip install 'merrypopins[cnn]'
+
+# Slim install, without TensorFlow
 pip install merrypopins
 
 # For development
 git clone https://github.com/SerpRateAI/merrypopins.git
 cd merrypopins
-pip install -e .
+pip install -e '.[cnn]'
 ```
 
 merrypopins supports Python 3.10+ and depends on:
@@ -105,9 +164,16 @@ merrypopins supports Python 3.10+ and depends on:
 - `pandas`
 - `scipy`
 - `scikit-learn`
-- `tensorflow`
 
 These are installed automatically via `pip`.
+
+**TensorFlow is optional.** It is only needed by the CNN autoencoder detector, one of
+the four methods in `locate`, and it is a several-hundred-megabyte download. Install
+it with the `cnn` extra shown above. Without it, `merrypopins` imports and runs
+normally and you can use the other three detectors via
+`default_locate(df, use_cnn=False)`; calling the CNN detector raises an `ImportError`
+telling you how to install the extra. See
+[Installation](https://serprateai.github.io/merrypopins/installation/) for details.
 
 All core and development dependencies are tested with Python 3.10 through 3.13.
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,3 +87,59 @@ These images highlight the complex deformation behavior analyzed by the `merrypo
 For a quick overview, see the [Quickstart](quickstart.md).
 
 Merrypopins is developed by [Cahit Acar](mailto:c.acar.business@gmail.com), [Anna Marcelissen](mailto:anna.marcelissen@live.nl), [Hugo van Schrojenstein Lantman](mailto:h.w.vanschrojensteinlantman@uu.nl), and [John M. Aiken](mailto:johnm.aiken@gmail.com).
+
+---
+
+## 🔄 Workflow
+
+The five modules form a pipeline. Each stage takes the DataFrame the previous stage
+produced, so you can stop anywhere, inspect the result, or swap in your own step.
+
+```mermaid
+flowchart LR
+    RAW[".txt curve<br/>.tdm/.tdx metadata"] --> LOAD["<b>load_datasets</b><br/>parse to DataFrame"]
+    LOAD --> PRE["<b>preprocess</b><br/>trim, find contact,<br/>zero the depth axis"]
+    PRE --> LOC["<b>locate</b><br/>four detectors +<br/>agreement score"]
+    LOC --> STAT["<b>statistics</b><br/>stress-strain, yield point,<br/>precursor & temporal stats"]
+    STAT --> OUT["annotated tables,<br/>summary stats, plots"]
+
+    subgraph WRAP["make_dataset.merrypopins_pipeline (convenience wrapper)"]
+        LOAD
+        PRE
+        LOC
+    end
+```
+
+`make_dataset.merrypopins_pipeline` runs the first three stages end to end on a single
+file and writes an overlay plot, which is the quickest way to check a curve.
+
+---
+
+## 🔎 Choosing a detection method
+
+`locate` offers four detectors. They are complementary rather than interchangeable:
+the two derivative methods are cheap and predictable, and the two unsupervised
+learning methods adapt to data whose pop-in sizes you do not know in advance.
+
+| Method | Function | How it flags a pop-in | Main parameters | TensorFlow | Cost | Suits |
+|---|---|---|---|---|---|---|
+| Savitzky-Golay | `detect_popins_savgol` | Polynomial-smoothed derivative of load, thresholded in standard deviations | `window_length`, `polyorder`, `threshold` | no | very low | A first pass over a large batch; smooth, low-noise curves |
+| Fourier derivative | `detect_popins_fd_fourier` | Derivative taken in the frequency domain, thresholded in standard deviations | `threshold`, `spacing` | no | very low | Sharp discontinuities, with almost nothing to tune |
+| Isolation Forest | `detect_popins_iforest` | Unsupervised outlier detection over (stiffness difference, curvature) | `contamination`, `window` | no | low | Curves where pop-in size and frequency are not known beforehand |
+| CNN autoencoder | `detect_popins_cnn` | Reconstruction error over sliding windows of the same two features | `window_size`, `epochs`, `threshold_multiplier` | **yes** | high | Noisy curves and subtle nonlinear signatures a fixed threshold misses |
+
+Neither learning method uses pre-trained weights. Both are fitted, unsupervised, on the
+curve you pass in, so no labelled training data is needed and results depend only on
+that curve and your parameters.
+
+`default_locate` runs the enabled methods and combines them into three columns:
+
+| Column | Meaning |
+|---|---|
+| `popin` | Any enabled method fired here (the inclusive union). Highest recall. |
+| `popin_score` | How many methods fired here, i.e. how strongly they agree. |
+| `popin_confident` | At least two methods agree. Use this when a false positive costs more than a missed event. |
+
+Comparing `popin_score` across methods is also a cheap self-consistency check: events
+that only one detector sees are worth inspecting on the overlay plot before you trust them.
+

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,13 +3,16 @@
 Install from PyPI (once published):
 
 ```bash
-# From PyPI
+# Full install, including the CNN pop-in detector (recommended)
+pip install 'merrypopins[cnn]'
+
+# Slim install, without TensorFlow
 pip install merrypopins
 
 # For development
 git clone https://github.com/SerpRateAI/merrypopins.git
 cd merrypopins
-pip install -e .
+pip install -e '.[cnn]'
 ```
 
 merrypopins supports Python 3.10+ and depends on:
@@ -19,11 +22,39 @@ merrypopins supports Python 3.10+ and depends on:
 - `pandas`
 - `scipy`
 - `scikit-learn`
-- `tensorflow`
 
 These are installed automatically via `pip`.
 
 All core and development dependencies are tested with Python 3.10 through 3.13.
+
+## Optional: TensorFlow for the CNN detector
+
+`merrypopins.locate` offers four pop-in detection methods. Three of them
+(Savitzky-Golay, Fourier derivative, Isolation Forest) need only the core
+dependencies above. The fourth, the convolutional autoencoder, needs
+[TensorFlow](https://www.tensorflow.org/), which is several hundred megabytes.
+
+Rather than make everyone pay that cost for one of four methods, TensorFlow is
+packaged as an optional extra:
+
+```bash
+pip install 'merrypopins[cnn]'
+```
+
+Without it, `merrypopins` imports and runs normally, and you can use the other three
+detectors:
+
+```python
+from merrypopins.locate import default_locate
+
+# Works on a slim install
+df = default_locate(df, use_cnn=False)
+```
+
+`default_locate` enables the CNN by default (`use_cnn=True`). On a slim install it
+raises an `ImportError` telling you to install the extra, rather than quietly
+returning results from three methods when you asked for four. If you want the
+default four-method pipeline, install the `cnn` extra.
 
 # Development & Testing
 

--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,7 @@ dependencies:
   - matplotlib>=3.7
   - pip
   - pip:
+      # tensorflow enables the CNN detector; drop this line and use
+      # merrypopins instead of merrypopins[cnn] for a lighter environment
       - tensorflow>=2.10
-      - merrypopins
+      - merrypopins[cnn]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,11 @@ markdown_extensions:
       generic: true
   - footnotes
   - pymdownx.mark
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.caret
   - pymdownx.mark
   - pymdownx.tilde

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "merrypopins"
-version = "1.0.4"
+version = "1.1.0"
 description = "Merrypopins: Automated pop-in detection for nano-indentation experiments tooling: load_datasets, preprocess, locate, statistics & make_dataset"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"
@@ -31,17 +31,26 @@ dependencies = [
   "numpy>=1.23",
   "pandas>=2.2",
   "scipy>=1.10",
-  "scikit-learn>=1.2",
-  "tensorflow>=2.10"
+  "scikit-learn>=1.2"
 ]
 [project.optional-dependencies]
+# TensorFlow is only needed by the CNN autoencoder detector in locate.py. It is a
+# large install, so it is kept out of the base dependencies. The other three
+# detection methods and every other module work without it.
+cnn = [
+  "tensorflow>=2.10"
+]
+all = [
+  "merrypopins[cnn]"
+]
 dev = [
   "black>=23.0",
   "coverage>=7.0",
   "pre-commit>=3.0",
   "pytest>=7.0",
   "pytest-cov>=4.0",
-  "ruff>=0.8.0"
+  "ruff>=0.8.0",
+  "tensorflow>=2.10"
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,6 @@ pre-commit>=3.0
 pytest>=7.0
 pytest-cov>=4.0
 ruff>=0.8.0
+
+# Needed to exercise the CNN detector in the test suite
+tensorflow>=2.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ numpy>=1.23
 pandas>=2.2
 scipy>=1.10
 scikit-learn>=1.2
+
+# Optional: only needed by the CNN autoencoder detector (merrypopins[cnn]).
+# The other three detection methods work without it.
 tensorflow>=2.10

--- a/src/merrypopins/load_datasets.py
+++ b/src/merrypopins/load_datasets.py
@@ -128,7 +128,7 @@ def load_txt(filepath: Path) -> pd.DataFrame:
     return df
 
 
-def load_tdm(filepath: Path):
+def load_tdm(filepath: Path) -> tuple[pd.DataFrame, pd.DataFrame]:
     """
     Load a .tdm metadata file into two DataFrames.
     Args:

--- a/src/merrypopins/locate.py
+++ b/src/merrypopins/locate.py
@@ -13,6 +13,15 @@ To ensure relevance, all detection methods operate only on the indentation curve
 This is because pop-in events occur during the loading phase of indentation. After reaching peak load, material unloading
 or post-penetration artifacts may dominate, which are irrelevant for pop-in analysis.
 
+None of the methods use pre-trained models. The IsolationForest and the convolutional
+autoencoder are both fitted, unsupervised, on the curve being analysed at call time,
+so no labelled training data and no shipped weights are required.
+
+The CNN method needs TensorFlow, which is **not** installed with the base package
+because it is a large dependency used by only one of the four methods. Install it with::
+
+    pip install 'merrypopins[cnn]'
+
 Provides:
 - compute_stiffness
 - compute_features
@@ -23,14 +32,19 @@ Provides:
 - default_locate (combines all methods)
 """
 
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas as pd
-import logging
-from sklearn.ensemble import IsolationForest
 from scipy.signal import savgol_filter
-from tensorflow.keras.models import Model
-from tensorflow.keras.layers import Input, Conv1D, MaxPooling1D, UpSampling1D
-from tensorflow.keras.callbacks import EarlyStopping
+from sklearn.ensemble import IsolationForest
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checkers
+    from tensorflow.keras.models import Model
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:
@@ -39,8 +53,50 @@ if not logger.handlers:
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 
+TENSORFLOW_INSTALL_HINT = (
+    "The CNN pop-in detector requires TensorFlow, which merrypopins does not "
+    "install by default because it is a large dependency used by only one of the "
+    "four detection methods. Install it with: pip install 'merrypopins[cnn]'"
+)
 
-def compute_stiffness(df, depth_col="Depth (nm)", load_col="Load (µN)", window=5):
+
+def _import_keras() -> SimpleNamespace:
+    """
+    Import the Keras symbols used by the CNN detector.
+
+    TensorFlow is an optional dependency (the ``cnn`` extra), so it is imported
+    lazily here rather than at module import time. This keeps the other three
+    detection methods, and every other merrypopins module, usable without it.
+
+    Returns:
+        SimpleNamespace: Namespace holding the Keras classes used below.
+
+    Raises:
+        ImportError: If TensorFlow is not installed, with the install command.
+    """
+    try:
+        from tensorflow.keras.callbacks import EarlyStopping
+        from tensorflow.keras.layers import Conv1D, Input, MaxPooling1D, UpSampling1D
+        from tensorflow.keras.models import Model
+    except ImportError as exc:
+        raise ImportError(TENSORFLOW_INSTALL_HINT) from exc
+
+    return SimpleNamespace(
+        Model=Model,
+        Input=Input,
+        Conv1D=Conv1D,
+        MaxPooling1D=MaxPooling1D,
+        UpSampling1D=UpSampling1D,
+        EarlyStopping=EarlyStopping,
+    )
+
+
+def compute_stiffness(
+    df: pd.DataFrame,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    window: int = 5,
+) -> pd.Series:
     """
     Compute local stiffness (dLoad/dDepth) using sliding-window linear regression.
 
@@ -84,8 +140,12 @@ def compute_stiffness(df, depth_col="Depth (nm)", load_col="Load (µN)", window=
 
 
 def compute_features(
-    df, depth_col="Depth (nm)", load_col="Load (µN)", window=5, return_derivatives=True
-):
+    df: pd.DataFrame,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    window: int = 5,
+    return_derivatives: bool = True,
+) -> pd.DataFrame:
     """
     Compute derived indentation features for anomaly detection.
 
@@ -115,7 +175,7 @@ def compute_features(
     return df2 if return_derivatives else df
 
 
-def find_max_load_index(df, load_col="Load (µN)"):
+def find_max_load_index(df: pd.DataFrame, load_col: str = "Load (µN)") -> int:
     """
     Find the index of the maximum load point in the indentation curve.
 
@@ -129,7 +189,7 @@ def find_max_load_index(df, load_col="Load (µN)"):
     return df[load_col].idxmax()
 
 
-def trim_edges(series, margin):
+def trim_edges(series: pd.Series | np.ndarray, margin: int) -> pd.Series | np.ndarray:
     """
     Trim the first `margin` elements of a pandas Series.
     This is useful for removing edge effects in time-series data where
@@ -145,17 +205,60 @@ def trim_edges(series, margin):
     return trimmed
 
 
+def _apply_trims(
+    flags: np.ndarray,
+    df: pd.DataFrame,
+    load_col: str,
+    trim_edges_enabled: bool,
+    trim_margin: int | None,
+    default_margin: int,
+    max_load_trim_enabled: bool,
+) -> np.ndarray:
+    """
+    Apply the two masks every detection method shares.
+
+    Each detector produces raw candidate flags and then discards those that fall in
+    the unreliable leading edge of the curve or after the maximum load point. That
+    tail is identical across methods and lives here so the four detectors differ only
+    in how they find candidates.
+
+    Args:
+        flags (ndarray): Boolean candidate flags, one per data point.
+        df (DataFrame): The indentation data the flags were computed from.
+        load_col (str): Column name for load data.
+        trim_edges_enabled (bool): If True, blank out the leading `trim_margin` points.
+        trim_margin (int or None): Number of leading elements to blank. If None,
+            `default_margin` is used instead.
+        default_margin (int): Margin used when `trim_margin` is None. Methods choose
+            this to match their own window size.
+        max_load_trim_enabled (bool): If True, blank out everything after max load.
+
+    Returns:
+        ndarray: The masked flags.
+    """
+    if trim_edges_enabled:
+        margin = trim_margin if trim_margin is not None else default_margin
+        flags = trim_edges(flags, margin=margin)
+
+    if max_load_trim_enabled:
+        # Mask out anything *after* max load
+        max_idx = find_max_load_index(df, load_col)
+        flags[max_idx + 1 :] = False
+
+    return flags
+
+
 def detect_popins_iforest(
-    df,
-    contamination=0.001,
-    random_state=None,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-    window=5,
-    trim_edges_enabled=True,
-    trim_margin=None,
-    max_load_trim_enabled=True,
-):
+    df: pd.DataFrame,
+    contamination: float = 0.001,
+    random_state: int | None = None,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    window: int = 5,
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    max_load_trim_enabled: bool = True,
+) -> pd.DataFrame:
     """
     Detect pop-ins using Isolation Forest based on local stiffness and curvature.
 
@@ -166,6 +269,9 @@ def detect_popins_iforest(
     It then applies the Isolation Forest algorithm from scikit-learn, which isolates
     anomalies by recursively partitioning the feature space. Points that require fewer
     partitions to isolate are more likely to be outliers.
+
+    The forest is fitted on the curve passed in; there is no pre-trained model and no
+    labelled training data is required.
 
     Args:
         df (DataFrame): Indentation dataset containing load and depth columns.
@@ -187,21 +293,23 @@ def detect_popins_iforest(
     iso = IsolationForest(contamination=contamination, random_state=random_state)
     features = df2[["stiff_diff", "curvature"]].fillna(0)
     preds = iso.fit_predict(features) == -1
-    if trim_edges_enabled:
-        margin = trim_margin if trim_margin is not None else max(10, window)
-        preds = trim_edges(preds, margin=margin)
 
-    if max_load_trim_enabled:
-        # Mask out anything *after* max load
-        max_idx = find_max_load_index(df, load_col)
-        preds[max_idx + 1 :] = False
+    preds = _apply_trims(
+        preds,
+        df,
+        load_col,
+        trim_edges_enabled,
+        trim_margin,
+        max(10, window),
+        max_load_trim_enabled,
+    )
 
     df2["popin_iforest"] = preds
     logger.info(f"IsolationForest flagged {df2['popin_iforest'].sum()} anomalies")
     return df2
 
 
-def build_cnn_autoencoder(window_size, n_features):
+def build_cnn_autoencoder(window_size: int, n_features: int) -> Model:
     """
     Build a 1D Convolutional Autoencoder for time-series anomaly detection.
 
@@ -225,34 +333,40 @@ def build_cnn_autoencoder(window_size, n_features):
 
     Returns:
         keras.Model: Keras autoencoder model (uncompiled).
+
+    Raises:
+        ImportError: If TensorFlow is not installed. Install it with
+            `pip install 'merrypopins[cnn]'`.
     """
-    inp = Input(shape=(window_size, n_features))
-    x = Conv1D(32, 3, activation="relu", padding="same")(inp)
-    x = MaxPooling1D(2, padding="same")(x)
-    x = Conv1D(16, 3, activation="relu", padding="same")(x)
-    x = MaxPooling1D(2, padding="same")(x)
-    x = Conv1D(16, 3, activation="relu", padding="same")(x)
-    x = UpSampling1D(2)(x)
-    x = Conv1D(32, 3, activation="relu", padding="same")(x)
-    x = UpSampling1D(2)(x)
-    x = Conv1D(n_features, 3, activation="linear", padding="same")(x)
-    return Model(inp, x)
+    keras = _import_keras()
+
+    inp = keras.Input(shape=(window_size, n_features))
+    x = keras.Conv1D(32, 3, activation="relu", padding="same")(inp)
+    x = keras.MaxPooling1D(2, padding="same")(x)
+    x = keras.Conv1D(16, 3, activation="relu", padding="same")(x)
+    x = keras.MaxPooling1D(2, padding="same")(x)
+    x = keras.Conv1D(16, 3, activation="relu", padding="same")(x)
+    x = keras.UpSampling1D(2)(x)
+    x = keras.Conv1D(32, 3, activation="relu", padding="same")(x)
+    x = keras.UpSampling1D(2)(x)
+    x = keras.Conv1D(n_features, 3, activation="linear", padding="same")(x)
+    return keras.Model(inp, x)
 
 
 def detect_popins_cnn(
-    df,
-    window_size=64,
-    epochs=10,
-    threshold_multiplier=5.0,
-    batch_size=32,
-    validation_split=0.0,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-    window=5,
-    trim_edges_enabled=True,
-    trim_margin=None,
-    max_load_trim_enabled=True,
-):
+    df: pd.DataFrame,
+    window_size: int = 64,
+    epochs: int = 10,
+    threshold_multiplier: float = 5.0,
+    batch_size: int = 32,
+    validation_split: float = 0.0,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    window: int = 5,
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    max_load_trim_enabled: bool = True,
+) -> pd.DataFrame:
     """
     Detect pop-ins using a Convolutional Autoencoder trained on stiffness features.
 
@@ -268,6 +382,8 @@ def detect_popins_cnn(
 
     The method uses a sliding window to extract overlapping sequences from the full curve,
     trains the model on all windows, and flags windows whose error exceeds a dynamic threshold.
+    The autoencoder is trained from scratch on the curve passed in, so no pre-trained
+    weights ship with the package and no labelled data is needed.
 
     Args:
         df (DataFrame): Input indentation data containing load and depth columns.
@@ -287,7 +403,13 @@ def detect_popins_cnn(
         DataFrame: Original DataFrame with a new boolean column:
             - "popin_cnn": True for detected anomalies, False otherwise.
                 - Only pre-max-load anomalies are returned to focus on loading-phase events. If `max_load_trim_enabled` is True which is the default.
+
+    Raises:
+        ImportError: If TensorFlow is not installed. Install it with
+            `pip install 'merrypopins[cnn]'`.
     """
+    keras = _import_keras()
+
     df2 = compute_features(df, depth_col, load_col, window)
     X = df2[["stiff_diff", "curvature"]].fillna(0).values
     W = np.array([X[i : i + window_size] for i in range(len(X) - window_size)])
@@ -302,7 +424,7 @@ def detect_popins_cnn(
         validation_split=validation_split,
         verbose=0,
         callbacks=(
-            [EarlyStopping(patience=3, restore_best_weights=True)]
+            [keras.EarlyStopping(patience=3, restore_best_weights=True)]
             if validation_split > 0
             else None
         ),
@@ -314,14 +436,16 @@ def detect_popins_cnn(
 
     flags = np.zeros(len(X), dtype=bool)
     flags[window_size // 2 : -window_size // 2] = errors > threshold
-    if trim_edges_enabled:
-        margin = trim_margin if trim_margin is not None else max(10, window)
-        flags = trim_edges(flags, margin=margin)
 
-    if max_load_trim_enabled:
-        # Mask out anything *after* max load
-        max_idx = find_max_load_index(df, load_col)
-        flags[max_idx + 1 :] = False
+    flags = _apply_trims(
+        flags,
+        df,
+        load_col,
+        trim_edges_enabled,
+        trim_margin,
+        max(10, window),
+        max_load_trim_enabled,
+    )
 
     df2["popin_cnn"] = flags
     logger.info(f"CNN flagged {df2['popin_cnn'].sum()} anomalies")
@@ -329,14 +453,14 @@ def detect_popins_cnn(
 
 
 def detect_popins_fd_fourier(
-    df,
-    threshold=3.0,
-    spacing=1.0,
-    trim_edges_enabled=True,
-    trim_margin=None,
-    load_col="Load (µN)",
-    max_load_trim_enabled=True,
-):
+    df: pd.DataFrame,
+    threshold: float = 3.0,
+    spacing: float = 1.0,
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    load_col: str = "Load (µN)",
+    max_load_trim_enabled: bool = True,
+) -> pd.DataFrame:
     """
     Detect pop-ins by estimating the derivative of Load using a Fourier spectral method.
 
@@ -373,14 +497,16 @@ def detect_popins_fd_fourier(
     anomalies = np.abs(derivative - np.mean(derivative)) > threshold * np.std(
         derivative
     )
-    if trim_edges_enabled:
-        margin = trim_margin if trim_margin is not None else 10
-        anomalies = trim_edges(anomalies, margin=margin)
 
-    if max_load_trim_enabled:
-        # Mask out anything *after* max load
-        max_idx = find_max_load_index(df, load_col)
-        anomalies[max_idx + 1 :] = False
+    anomalies = _apply_trims(
+        anomalies,
+        df,
+        load_col,
+        trim_edges_enabled,
+        trim_margin,
+        10,
+        max_load_trim_enabled,
+    )
 
     df2 = df.copy()
     df2["popin_fd"] = anomalies
@@ -389,16 +515,16 @@ def detect_popins_fd_fourier(
 
 
 def detect_popins_savgol(
-    df,
-    window_length=11,
-    polyorder=2,
-    threshold=3.0,
-    deriv=1,
-    load_col="Load (µN)",
-    trim_edges_enabled=True,
-    trim_margin=None,
-    max_load_trim_enabled=True,
-):
+    df: pd.DataFrame,
+    window_length: int = 11,
+    polyorder: int = 2,
+    threshold: float = 3.0,
+    deriv: int = 1,
+    load_col: str = "Load (µN)",
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    max_load_trim_enabled: bool = True,
+) -> pd.DataFrame:
     """
     Detect pop-ins using Savitzky-Golay filtered derivatives.
 
@@ -431,14 +557,16 @@ def detect_popins_savgol(
     anomalies = np.abs(derivative - np.mean(derivative)) > threshold * np.std(
         derivative
     )
-    if trim_edges_enabled:
-        margin = trim_margin if trim_margin is not None else max(10, window_length)
-        anomalies = trim_edges(anomalies, margin=margin)
 
-    if max_load_trim_enabled:
-        # Mask out anything *after* max load
-        max_idx = find_max_load_index(df, load_col)
-        anomalies[max_idx + 1 :] = False
+    anomalies = _apply_trims(
+        anomalies,
+        df,
+        load_col,
+        trim_edges_enabled,
+        trim_margin,
+        max(10, window_length),
+        max_load_trim_enabled,
+    )
 
     df2 = df.copy()
     df2["popin_savgol"] = anomalies
@@ -446,38 +574,53 @@ def detect_popins_savgol(
     return df2
 
 
-# default_locate implementation combining all methods with popin flag.
-...
-
-
 def default_locate(
-    df,
-    iforest_contamination=0.001,
-    iforest_random_state=None,
-    cnn_window_size=64,
-    cnn_epochs=10,
-    cnn_threshold_multiplier=5.0,
-    cnn_batch_size=32,
-    cnn_validation_split=0.0,
-    fd_threshold=3.0,
-    fd_spacing=1.0,
-    savgol_window_length=11,
-    savgol_polyorder=2,
-    savgol_threshold=3.0,
-    sg_deriv_order=1,
-    stiffness_window=5,
-    trim_edges_enabled=True,
-    trim_margin=None,
-    max_load_trim_enabled=True,
-    use_iforest=True,
-    use_cnn=True,
-    use_fd=True,
-    use_savgol=True,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-):
+    df: pd.DataFrame,
+    iforest_contamination: float = 0.001,
+    iforest_random_state: int | None = None,
+    cnn_window_size: int = 64,
+    cnn_epochs: int = 10,
+    cnn_threshold_multiplier: float = 5.0,
+    cnn_batch_size: int = 32,
+    cnn_validation_split: float = 0.0,
+    fd_threshold: float = 3.0,
+    fd_spacing: float = 1.0,
+    savgol_window_length: int = 11,
+    savgol_polyorder: int = 2,
+    savgol_threshold: float = 3.0,
+    sg_deriv_order: int = 1,
+    stiffness_window: int = 5,
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    max_load_trim_enabled: bool = True,
+    use_iforest: bool = True,
+    use_cnn: bool = True,
+    use_fd: bool = True,
+    use_savgol: bool = True,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+) -> pd.DataFrame:
     """
     Apply all (default) or selected detection methods to identify pop-ins.
+
+    Each enabled method writes its own boolean column ("popin_iforest", "popin_cnn",
+    "popin_fd", "popin_savgol"). Those are then combined into three summary columns:
+
+      - "popin": True where *any* enabled method fired (the inclusive union).
+      - "popin_score": how many methods fired at that point, i.e. how much the
+        methods agree.
+      - "popin_confident": True where at least two methods agree, which is the
+        column to use when false positives are more costly than missed events.
+
+    The methods are complementary rather than interchangeable. Savitzky-Golay and the
+    Fourier derivative are cheap, need only a couple of parameters, and suit a first
+    pass over a large batch. The IsolationForest and CNN autoencoder are unsupervised
+    and adapt to the data, which helps on noisy curves or unfamiliar materials where a
+    fixed derivative threshold does not transfer, at a higher compute cost.
+
+    Note that `use_cnn=True` (the default) needs TensorFlow, an optional dependency.
+    Install it with `pip install 'merrypopins[cnn]'`, or pass `use_cnn=False` to run
+    the other three methods without it.
 
     Args:
         df (DataFrame): Input indentation data.
@@ -507,6 +650,10 @@ def default_locate(
 
     Returns:
         DataFrame: Data with individual method flags, combined flag, and metadata columns.
+
+    Raises:
+        ImportError: If `use_cnn` is True and TensorFlow is not installed. Install it
+            with `pip install 'merrypopins[cnn]'` or pass `use_cnn=False`.
     """
     df_combined = df.copy()
     method_flags = []

--- a/src/merrypopins/locate.py
+++ b/src/merrypopins/locate.py
@@ -205,6 +205,36 @@ def trim_edges(series: pd.Series | np.ndarray, margin: int) -> pd.Series | np.nd
     return trimmed
 
 
+def _flag_outliers(signal: np.ndarray, threshold: float) -> np.ndarray:
+    """
+    Flag points where a signal departs from its own mean by more than `threshold` sigma.
+
+    Both derivative-based detectors score candidates this way, so the rule lives here.
+
+    A constant signal needs care. If the curve is perfectly smooth its derivative is
+    constant, and the standard deviation that would set the scale is floating-point
+    noise around zero rather than a real spread. Comparing against it flags arbitrary
+    points. A perfectly smooth curve contains no pop-ins, so nothing is flagged when
+    the spread is negligible relative to the signal itself.
+
+    Args:
+        signal (ndarray): The derivative (or other score) to threshold.
+        threshold (float): Number of standard deviations that counts as an anomaly.
+
+    Returns:
+        ndarray: Boolean flags, one per point.
+    """
+    signal = np.asarray(signal, dtype=float)
+    spread = np.std(signal)
+    scale = np.max(np.abs(signal)) if signal.size else 0.0
+
+    if not np.isfinite(spread) or spread <= 1e-12 * max(scale, 1.0):
+        logger.debug("Signal is effectively constant; no anomalies flagged.")
+        return np.zeros(signal.shape, dtype=bool)
+
+    return np.abs(signal - np.mean(signal)) > threshold * spread
+
+
 def _apply_trims(
     flags: np.ndarray,
     df: pd.DataFrame,
@@ -474,7 +504,8 @@ def detect_popins_fd_fourier(
     IFFT takes frequency-domain data and reconstructs the original time-domain (or spatial) signal.
 
     Anomalies are flagged where the resulting derivative deviates from the mean by more than a
-    given number of standard deviations.
+    given number of standard deviations. A perfectly smooth curve has a constant derivative
+    and no pop-ins, so nothing is flagged when that spread is negligible.
 
     Args:
         df (DataFrame): Input indentation data.
@@ -494,9 +525,7 @@ def detect_popins_fd_fourier(
     fft_load = np.fft.fft(load)
     freqs = np.fft.fftfreq(len(load), d=spacing)
     derivative = np.real(np.fft.ifft(1j * 2 * np.pi * freqs * fft_load))
-    anomalies = np.abs(derivative - np.mean(derivative)) > threshold * np.std(
-        derivative
-    )
+    anomalies = _flag_outliers(derivative, threshold)
 
     anomalies = _apply_trims(
         anomalies,
@@ -534,6 +563,8 @@ def detect_popins_savgol(
     The steps are:
       1. Apply Savitzky-Golay filter to compute the derivative (e.g., velocity or acceleration)
       2. Flag points where |derivative - mean| > threshold * std deviation
+         (nothing is flagged if the derivative is constant, i.e. the curve is
+         perfectly smooth and therefore contains no pop-ins)
 
     The Savitzky-Golay filter works by fitting successive subsets of adjacent data points
     with a low-degree polynomial using linear least squares.
@@ -554,9 +585,7 @@ def detect_popins_savgol(
                 - Only pre-max-load anomalies are returned to focus on loading-phase events. If `max_load_trim_enabled` is True which is the default.
     """
     derivative = savgol_filter(df[load_col], window_length, polyorder, deriv=deriv)
-    anomalies = np.abs(derivative - np.mean(derivative)) > threshold * np.std(
-        derivative
-    )
+    anomalies = _flag_outliers(derivative, threshold)
 
     anomalies = _apply_trims(
         anomalies,

--- a/src/merrypopins/make_dataset.py
+++ b/src/merrypopins/make_dataset.py
@@ -13,40 +13,43 @@ Provides:
 - Returns a DataFrame with all annotations.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
 import matplotlib.pyplot as plt
+import pandas as pd
 from merrypopins.load_datasets import load_txt
 from merrypopins.preprocess import default_preprocess
 from merrypopins.locate import default_locate
 
 
 def merrypopins_pipeline(
-    txt_path,
-    iforest_contamination=0.001,
-    iforest_random_state=None,
-    cnn_window_size=64,
-    cnn_epochs=10,
-    cnn_threshold_multiplier=5.0,
-    cnn_batch_size=32,
-    cnn_validation_split=0.0,
-    fd_threshold=3.0,
-    fd_spacing=1.0,
-    savgol_window_length=11,
-    savgol_polyorder=2,
-    savgol_threshold=3.0,
-    sg_deriv_order=1,
-    stiffness_window=5,
-    trim_edges_enabled=True,
-    trim_margin=None,
-    max_load_trim_enabled=True,
-    use_iforest=True,
-    use_cnn=True,
-    use_fd=True,
-    use_savgol=True,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-    save_plot_dir=Path("visualisations"),
-):
+    txt_path: Path,
+    iforest_contamination: float = 0.001,
+    iforest_random_state: int | None = None,
+    cnn_window_size: int = 64,
+    cnn_epochs: int = 10,
+    cnn_threshold_multiplier: float = 5.0,
+    cnn_batch_size: int = 32,
+    cnn_validation_split: float = 0.0,
+    fd_threshold: float = 3.0,
+    fd_spacing: float = 1.0,
+    savgol_window_length: int = 11,
+    savgol_polyorder: int = 2,
+    savgol_threshold: float = 3.0,
+    sg_deriv_order: int = 1,
+    stiffness_window: int = 5,
+    trim_edges_enabled: bool = True,
+    trim_margin: int | None = None,
+    max_load_trim_enabled: bool = True,
+    use_iforest: bool = True,
+    use_cnn: bool = True,
+    use_fd: bool = True,
+    use_savgol: bool = True,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    save_plot_dir: Path = Path("visualisations"),
+) -> pd.DataFrame:
     """
     Executes the full Merrypopins pipeline: load -> preprocess -> locate -> visualize.
 

--- a/src/merrypopins/preprocess.py
+++ b/src/merrypopins/preprocess.py
@@ -33,7 +33,7 @@ if not logger.handlers:
     logger.setLevel(logging.INFO)
 
 
-def remove_pre_min_load(df: pd.DataFrame, load_col="Load (µN)") -> pd.DataFrame:
+def remove_pre_min_load(df: pd.DataFrame, load_col: str = "Load (µN)") -> pd.DataFrame:
     """
     Remove all points up to and including the minimum Load point.
 
@@ -61,12 +61,12 @@ def remove_pre_min_load(df: pd.DataFrame, load_col="Load (µN)") -> pd.DataFrame
 
 def rescale_data(
     df: pd.DataFrame,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-    N_baseline=50,
-    k=5,
-    window_length=11,
-    polyorder=2,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    N_baseline: int = 50,
+    k: float = 5,
+    window_length: int = 11,
+    polyorder: int = 2,
 ) -> pd.DataFrame:
     """
     Automatically detect contact point by noise threshold and rescale Depth so contact = 0.

--- a/src/merrypopins/statistics.py
+++ b/src/merrypopins/statistics.py
@@ -27,7 +27,9 @@ if not logger.handlers:
 ####### POSTPROCESSING #########
 
 
-def postprocess_popins_local_max(df, popin_flag_column="popin", window=1):
+def postprocess_popins_local_max(
+    df: pd.DataFrame, popin_flag_column: str = "popin", window: int = 1
+) -> pd.DataFrame:
     """
     Select pop-ins that have a local load maxima.
 
@@ -67,7 +69,11 @@ def postprocess_popins_local_max(df, popin_flag_column="popin", window=1):
     return df
 
 
-def extract_popin_intervals(df, popin_col="popin_selected", load_col="Load (µN)"):
+def extract_popin_intervals(
+    df: pd.DataFrame,
+    popin_col: str = "popin_selected",
+    load_col: str = "Load (µN)",
+) -> pd.DataFrame:
     """
     Extract start and end indices for each pop-in event.
 
@@ -106,8 +112,14 @@ def extract_popin_intervals(df, popin_col="popin_selected", load_col="Load (µN)
 
 
 def _compute_temporal_stats(
-    start_time, end_time, interval_rows, i, df, time_col, start_col
-):
+    start_time: float,
+    end_time: float,
+    interval_rows: pd.DataFrame,
+    i: int,
+    df: pd.DataFrame,
+    time_col: str,
+    start_col: str,
+) -> dict:
     """
     Compute temporal statistics for each pop-in event.
 
@@ -142,7 +154,9 @@ def _compute_temporal_stats(
     }
 
 
-def _compute_precursor_stats(before, time_col, load_col):
+def _compute_precursor_stats(
+    before: pd.DataFrame, time_col: str, load_col: str
+) -> dict:
     """
     Compute the precursor statistics before the pop-in event.
 
@@ -168,7 +182,14 @@ def _compute_precursor_stats(before, time_col, load_col):
     }
 
 
-def _compute_shape_stats(df, start_idx, end_idx, during, time_col, depth_col):
+def _compute_shape_stats(
+    df: pd.DataFrame,
+    start_idx: int,
+    end_idx: int,
+    during: pd.DataFrame,
+    time_col: str,
+    depth_col: str,
+) -> dict:
     """
     Compute shape statistics during the pop-in event.
 
@@ -210,18 +231,18 @@ def _compute_shape_stats(df, start_idx, end_idx, during, time_col, depth_col):
 
 
 def calculate_popin_statistics(
-    df,
-    precursor_stats=True,
-    temporal_stats=True,
-    popin_shape_stats=True,
-    time_col="Time (s)",
-    load_col="Load (µN)",
-    depth_col="Depth (nm)",
-    start_col="start_idx",
-    end_col="end_idx",
-    before_window=0.5,
-    after_window=0.5,
-):
+    df: pd.DataFrame,
+    precursor_stats: bool = True,
+    temporal_stats: bool = True,
+    popin_shape_stats: bool = True,
+    time_col: str = "Time (s)",
+    load_col: str = "Load (µN)",
+    depth_col: str = "Depth (nm)",
+    start_col: str = "start_idx",
+    end_col: str = "end_idx",
+    before_window: float = 0.5,
+    after_window: float = 0.5,
+) -> pd.DataFrame:
     """
     Compute descriptive statistics for each detected pop-in.
 
@@ -290,8 +311,11 @@ def calculate_popin_statistics(
 
 
 def calculate_curve_summary(
-    df, start_col="start_idx", end_col="end_idx", time_col="Time (s)"
-):
+    df: pd.DataFrame,
+    start_col: str = "start_idx",
+    end_col: str = "end_idx",
+    time_col: str = "Time (s)",
+) -> pd.Series:
     """
     Compute curve-level summary statistics about pop-in activity.
 
@@ -338,8 +362,11 @@ def calculate_curve_summary(
 
 
 def default_statistics(
-    df_locate, popin_flag_column="popin", before_window=0.5, after_window=0.5
-):
+    df_locate: pd.DataFrame,
+    popin_flag_column: str = "popin",
+    before_window: float = 0.5,
+    after_window: float = 0.5,
+) -> pd.DataFrame:
     """
     Pipeline to compute pop-in statistics from raw located popins.
 
@@ -379,16 +406,16 @@ def default_statistics(
 
 
 def calculate_stress_strain(
-    df,
-    depth_col="Depth (nm)",
-    load_col="Load (µN)",
-    Reff_um=5.323,
-    min_load_uN=2000,
-    smooth_stress=True,
-    smooth_window=11,
-    smooth_polyorder=2,
-    copy_popin_cols=True,
-):
+    df: pd.DataFrame,
+    depth_col: str = "Depth (nm)",
+    load_col: str = "Load (µN)",
+    Reff_um: float = 5.323,
+    min_load_uN: float = 2000,
+    smooth_stress: bool = True,
+    smooth_window: int = 11,
+    smooth_polyorder: int = 2,
+    copy_popin_cols: bool = True,
+) -> pd.DataFrame:
     """
     Convert load–depth data to stress–strain using Kalidindi & Pathak (2008) formulas.
 
@@ -461,7 +488,9 @@ def calculate_stress_strain(
 ### Helper Functions stress-strain ####
 
 
-def _compute_stress_strain_jump_stats(df, start_idx, end_idx, stress_col, strain_col):
+def _compute_stress_strain_jump_stats(
+    df: pd.DataFrame, start_idx: int, end_idx: int, stress_col: str, strain_col: str
+) -> dict:
     """
     Compute the jump in stress and strain during a pop-in event.
 
@@ -481,7 +510,9 @@ def _compute_stress_strain_jump_stats(df, start_idx, end_idx, stress_col, strain
     }
 
 
-def _compute_stress_strain_shape_stats(during, time_col, stress_col, strain_col):
+def _compute_stress_strain_shape_stats(
+    during: pd.DataFrame, time_col: str, stress_col: str, strain_col: str
+) -> dict:
     """
     Compute shape-based statistics such as stress slope, strain slope, and average stress/strain during the pop-in.
 
@@ -517,7 +548,9 @@ def _compute_stress_strain_shape_stats(during, time_col, stress_col, strain_col)
     }
 
 
-def _compute_stress_strain_precursor_stats(before, time_col, stress_col, strain_col):
+def _compute_stress_strain_precursor_stats(
+    before: pd.DataFrame, time_col: str, stress_col: str, strain_col: str
+) -> dict:
     """
     Compute precursor statistics like the average change in stress and strain before the pop-in.
 
@@ -554,17 +587,17 @@ def _compute_stress_strain_precursor_stats(before, time_col, stress_col, strain_
 
 
 def calculate_stress_strain_statistics(
-    df,
-    start_col="start_idx",
-    end_col="end_idx",
-    time_col="Time (s)",
-    stress_col="stress",
-    strain_col="strain",
-    before_window=0.5,
-    precursor_stats=True,
-    temporal_stats=True,
-    shape_stats=True,
-):
+    df: pd.DataFrame,
+    start_col: str = "start_idx",
+    end_col: str = "end_idx",
+    time_col: str = "Time (s)",
+    stress_col: str = "stress",
+    strain_col: str = "strain",
+    before_window: float = 0.5,
+    precursor_stats: bool = True,
+    temporal_stats: bool = True,
+    shape_stats: bool = True,
+) -> pd.DataFrame:
     """
     Compute statistics for each pop-in in stress–strain space.
 
@@ -643,17 +676,17 @@ def calculate_stress_strain_statistics(
 
 
 def default_statistics_stress_strain(
-    df_locate,
-    popin_flag_column="popin",
-    before_window=0.5,
-    after_window=0.5,
-    Reff_um=5.323,
-    min_load_uN=2000,
-    smooth_stress=True,
-    stress_col="stress",
-    strain_col="strain",
-    time_col="Time (s)",
-):
+    df_locate: pd.DataFrame,
+    popin_flag_column: str = "popin",
+    before_window: float = 0.5,
+    after_window: float = 0.5,
+    Reff_um: float = 5.323,
+    min_load_uN: float = 2000,
+    smooth_stress: bool = True,
+    stress_col: str = "stress",
+    strain_col: str = "strain",
+    time_col: str = "Time (s)",
+) -> pd.DataFrame:
     """
     Full pipeline: from raw data to stress–strain statistics.
 

--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
 plotly<6.0.0
 pandas
-merrypopins
+merrypopins[cnn]
 kaleido<1.0.0

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -72,6 +72,13 @@ def test_stiffness_too_few_points():
 # detect_popins_fd_fourier
 # ----------------------------------------------------------------------
 def test_detect_popins_fd_fourier_no_jump(simple_curve):
+    """A straight curve should yield at most the FFT wrap-around artifact.
+
+    Unlike the Savitzky-Golay case, the spectral derivative of a non-periodic ramp
+    is not constant: treating the curve as periodic introduces a large step at the
+    wrap-around, so the endpoints carry a genuine spike. The leading edge is trimmed;
+    the final point can survive.
+    """
     df0 = detect_popins_fd_fourier(simple_curve, threshold=3.0)
     n0 = df0["popin_fd"].sum()
     assert n0 <= 3
@@ -87,10 +94,16 @@ def test_detect_popins_fd_fourier_with_jump(curve_with_jump):
 # detect_popins_savgol
 # ----------------------------------------------------------------------
 def test_detect_popins_savgol_no_jump(simple_curve):
+    """A perfectly straight curve has no pop-ins, so nothing should be flagged.
+
+    Without the constant-signal guard in _flag_outliers, the derivative's standard
+    deviation here is float noise around zero and the threshold comparison flags
+    arbitrary points near the filter edges.
+    """
     df0 = detect_popins_savgol(
         simple_curve, window_length=11, polyorder=2, threshold=3.0
     )
-    assert df0["popin_savgol"].sum() <= 3
+    assert df0["popin_savgol"].sum() == 0
 
 
 def test_detect_popins_savgol_with_jump(curve_with_jump):
@@ -99,6 +112,30 @@ def test_detect_popins_savgol_with_jump(curve_with_jump):
     )
     assert df1["popin_savgol"].sum() > 0
     assert df1["popin_savgol"].iloc[48:53].any()
+
+
+# ----------------------------------------------------------------------
+# _flag_outliers: the shared thresholding rule
+# ----------------------------------------------------------------------
+def test_flag_outliers_finds_the_spike():
+    signal = np.zeros(100)
+    signal[42] = 50.0
+    flags = locate._flag_outliers(signal, threshold=3.0)
+    assert flags[42]
+    assert flags.sum() == 1
+
+
+@pytest.mark.parametrize(
+    "signal",
+    [
+        np.zeros(50),  # all zero
+        np.full(50, 7.5),  # non-zero constant
+        np.full(50, 2.0) + np.linspace(0, 1e-15, 50),  # constant to float precision
+    ],
+)
+def test_flag_outliers_ignores_constant_signals(signal):
+    """A constant signal has no real spread, so its 'sigma' is float noise."""
+    assert not locate._flag_outliers(signal, threshold=3.0).any()
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -1,7 +1,10 @@
+import builtins
+
 import numpy as np
 import pandas as pd
 import pytest
 
+from merrypopins import locate
 from merrypopins.locate import (
     compute_stiffness,
     compute_features,
@@ -124,6 +127,64 @@ def test_detect_popins_cnn_basic(curve_with_jump):
     assert flags > 0
     idxs = np.where(df_cnn["popin_cnn"])[0]
     assert idxs.min() >= 10 and idxs.max() <= len(curve_with_jump) - 10
+
+
+# ----------------------------------------------------------------------
+# TensorFlow is an optional dependency (the "cnn" extra). Everything except the
+# CNN detector must work without it, and the CNN entry points must say how to
+# install it rather than raising a bare ModuleNotFoundError.
+# ----------------------------------------------------------------------
+@pytest.fixture
+def no_tensorflow(monkeypatch):
+    """Make any `import tensorflow...` inside merrypopins fail."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name.startswith("tensorflow"):
+            raise ImportError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+
+def test_import_keras_without_tensorflow_explains_install(no_tensorflow):
+    with pytest.raises(ImportError, match=r"merrypopins\[cnn\]"):
+        locate._import_keras()
+
+
+def test_detect_popins_cnn_without_tensorflow_explains_install(
+    curve_with_jump, no_tensorflow
+):
+    with pytest.raises(ImportError, match=r"merrypopins\[cnn\]"):
+        detect_popins_cnn(curve_with_jump, window_size=20, epochs=1)
+
+
+def test_build_cnn_autoencoder_without_tensorflow_explains_install(no_tensorflow):
+    with pytest.raises(ImportError, match=r"merrypopins\[cnn\]"):
+        locate.build_cnn_autoencoder(20, 2)
+
+
+def test_other_methods_work_without_tensorflow(curve_with_jump, no_tensorflow):
+    """The three non-CNN detectors must not need TensorFlow."""
+    df = default_locate(
+        curve_with_jump,
+        use_cnn=False,
+        iforest_contamination=0.01,
+        iforest_random_state=42,
+        savgol_threshold=1.0,
+    )
+    for col in ("popin_iforest", "popin_fd", "popin_savgol", "popin"):
+        assert col in df.columns
+    assert "popin_cnn" not in df.columns
+    assert df["popin"].sum() > 0
+
+
+def test_default_locate_without_tensorflow_explains_install(
+    curve_with_jump, no_tensorflow
+):
+    """use_cnn defaults to True, so it must fail loudly rather than silently skip."""
+    with pytest.raises(ImportError, match=r"merrypopins\[cnn\]"):
+        default_locate(curve_with_jump, cnn_window_size=20, cnn_epochs=1)
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Addresses the code-side items from the JOSS review
([openjournals/joss-reviews#9933](https://github.com/openjournals/joss-reviews/issues/9933))
and closes #72.

## TensorFlow becomes an optional extra

TensorFlow is needed only by the CNN autoencoder, one of four detectors in `locate`,
and it is a several-hundred-megabyte install every user was paying for. It now lives
in a `cnn` extra:

```bash
pip install merrypopins            # three detectors, lightweight
pip install 'merrypopins[cnn]'     # adds the autoencoder
```

- Keras is imported lazily inside `build_cnn_autoencoder` and `detect_popins_cnn`,
  which raise an `ImportError` naming the install command instead of a bare
  `ModuleNotFoundError`.
- `default_locate` keeps `use_cnn=True`, so a slim install raises rather than quietly
  returning three methods' results when four were requested. Pass `use_cnn=False` for
  the lightweight pipeline.
- Conda, Docker, dev and Streamlit environments still install TensorFlow, so the
  tutorials and the hosted app are unaffected.
- A new `slim-install` CI job installs the base package, asserts TensorFlow is absent,
  and runs the tests that do not need it, so this path cannot silently rot.

## Bug fix: no pop-ins on a perfectly smooth curve

Both derivative-based detectors scored candidates as a departure from the mean in
units of the derivative's standard deviation. On a smooth curve the derivative is
constant, so that standard deviation is floating-point noise around zero rather than a
real scale, and the comparison flagged points essentially at random near the filter
edges. The new shared `_flag_outliers` helper returns nothing when the spread is
negligible relative to the signal.

This was latent: `test_detect_popins_savgol_no_jump` papered over it with a `<= 3`
tolerance that held on the versions CI resolved in January and fails on SciPy 1.18 /
NumPy 2.5. It now asserts zero.

## Also

- Type hints on the public API of all five modules.
- The four `detect_popins_*` functions shared an identical tail (trim edge, mask past
  max load, write flag, log count); that is now one `_apply_trims` helper. No public
  API or behaviour change.
- A Mermaid pipeline diagram and a detection-method comparison table in the README and
  docs, plus guidance on `popin`, `popin_score` and `popin_confident`.
- Version bumped to 1.1.0 with a CHANGELOG entry.

## Verification

- `pytest` green: 68 passed.
- `ruff` and `black` clean at the versions pinned in `.pre-commit-config.yaml`.
- `mkdocs build` succeeds and renders the diagram and tables.
- Slim install verified: `import merrypopins.locate` works with no TensorFlow, the
  three-method pipeline runs, and the CNN entry points raise the helpful `ImportError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)