### PR TITLE
Bump __version__ to 1.1.0 to match pyproject.toml

### DIFF
--- a/src/merrypopins/__init__.py
+++ b/src/merrypopins/__init__.py
@@ -11,7 +11,7 @@ A modular pipeline for nanoindentation analysis. Includes tools for:
  - `make_dataset`: Construct enriched datasets by running the full pipeline and exporting annotated results and visualizations.
 """
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"
 
 # Expose submodules at the package level
 from . import load_datasets, preprocess, locate, statistics, make_dataset


### PR DESCRIPTION
One-line follow-up to #75.

The PyPI release workflow validates that `pyproject.toml` and
`src/merrypopins/__init__.py` carry the same version, and refuses to publish
otherwise. #75 bumped `pyproject.toml` to `1.1.0` but left `__init__.py` at `1.0.4`,
so merging `dev` into `main` would have failed at the version-check step before
building anything.

```
pyproject.toml            version = "1.1.0"
src/merrypopins/__init__  __version__ = "1.0.4"   <- now 1.1.0
```

Needs to land before `dev` → `main` for the v1.1.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)