### PR TITLE
Sync JOSS branch with dev for v1.1.0

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -87,7 +87,7 @@ jobs:
 
     steps:
     - name: Create GitHub release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: v${{ needs.version-check-and-pypi-publish.outputs.version }}
         generate_release_notes: true

--- a/src/merrypopins/__init__.py
+++ b/src/merrypopins/__init__.py
@@ -11,7 +11,7 @@ A modular pipeline for nanoindentation analysis. Includes tools for:
  - `make_dataset`: Construct enriched datasets by running the full pipeline and exporting annotated results and visualizations.
 """
 
-__version__ = "1.0.4"
+__version__ = "1.1.0"
 
 # Expose submodules at the package level
 from . import load_datasets, preprocess, locate, statistics, make_dataset


### PR DESCRIPTION
Housekeeping so the `JOSS` branch matches the released software the paper describes.

#76 merged into `JOSS` before #77 landed on `dev`, so the paper branch was left
internally inconsistent:

```
pyproject.toml            version = "1.1.0"
src/merrypopins/__init__  __version__ = "1.0.4"   <- now 1.1.0
```

A reviewer checking out this branch would have seen a version that does not match the
v1.1.0 release the revised paper refers to.

Merges `dev` into `JOSS`. Two changes only:

- `src/merrypopins/__init__.py` — version fix from #77
- `.github/workflows/pypi-release.yml` — dependabot bump of `softprops/action-gh-release` v2 → v3

`docs/paper.md`, `docs/paper.bib` and `.github/workflows/draft-pdf.yml` are untouched
and remain exclusive to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)