### PR TITLE
Add Zenodo archival metadata, bump to 1.1.1

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,33 @@
+{
+  "upload_type": "software",
+  "title": "merrypopins: A Python package for nanoindentation data science",
+  "description": "merrypopins is a Python library to streamline the workflow of nanoindentation experiment data processing, automated pop-in detection, and statistical analysis of collections of pop-in events. It provides five modules: load_datasets, preprocess, locate, statistics, and make_dataset, along with a no-code Streamlit interface.",
+  "license": "MIT",
+  "access_right": "open",
+  "creators": [
+    {
+      "name": "Acar, Cahit",
+      "affiliation": "Utrecht University, The Netherlands"
+    },
+    {
+      "name": "Marcelissen, Anna",
+      "affiliation": "Utrecht University, The Netherlands"
+    },
+    {
+      "name": "van Schrojenstein Lantman, Hugo",
+      "affiliation": "Utrecht University, The Netherlands"
+    },
+    {
+      "name": "Aiken, John M.",
+      "affiliation": "Utrecht University, The Netherlands"
+    }
+  ],
+  "keywords": [
+    "Python",
+    "geology",
+    "nanoindentation",
+    "deformation",
+    "pop-in detection",
+    "materials science"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,15 @@ and to [#72](https://github.com/SerpRateAI/merrypopins/issues/72).
   and runs the tests that do not need it.
 - Tests covering the missing-TensorFlow path for `_import_keras`,
   `build_cnn_autoencoder`, `detect_popins_cnn` and `default_locate`.
+
+---
+
+## [1.1.1] - 2026-08-11 &nbsp;:card_index_dividers: **"Archival Metadata"**
+
+### Added
+- `.zenodo.json` so the Zenodo archive of each release carries the same title,
+  author list, affiliations and MIT license as the JOSS paper, rather than the
+  repository name and description GitHub supplies by default.
+
+No changes to the library itself. `merrypopins` 1.1.1 is functionally identical
+to 1.1.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "merrypopins"
-version = "1.1.0"
+version = "1.1.1"
 description = "Merrypopins: Automated pop-in detection for nano-indentation experiments tooling: load_datasets, preprocess, locate, statistics & make_dataset"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/src/merrypopins/__init__.py
+++ b/src/merrypopins/__init__.py
@@ -11,7 +11,7 @@ A modular pipeline for nanoindentation analysis. Includes tools for:
  - `make_dataset`: Construct enriched datasets by running the full pipeline and exporting annotated results and visualizations.
 """
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 # Expose submodules at the package level
 from . import load_datasets, preprocess, locate, statistics, make_dataset


### PR DESCRIPTION
Adds `.zenodo.json` so the Zenodo archive of each release carries the same title, author list, affiliations and MIT license as the JOSS paper. Without it Zenodo names the record after the GitHub repository and tag, which does not match the paper and is the usual reason JOSS editors reject an archive.

The version bump to 1.1.1 is there to give the GitHub-Zenodo integration something to archive. The integration only picks up releases created after it is switched on, and 1.1.0 predates that.

No library code changes. 1.1.1 is functionally identical to 1.1.0.

Zenodo allows one affiliation per creator, so John M. Aiken's three affiliations collapse to the first one listed in the paper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)